### PR TITLE
增加Nodejs标识，修正Gihub为Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 <img src="./resources/images/icon.jpg" width = 200px height = 200px/>
 <br>
-<img src="https://img.shields.io/badge/Gihub-综合插件-skyblue?style=flat-square&logo=github"/>
+<img src="https://img.shields.io/badge/-Node.js-3C873A?style=flat&logo=Node.js&logoColor=white"/>
+<img src="https://img.shields.io/badge/Github-综合插件-skyblue?style=flat-square&logo=github"/>
 <img src ="https://img.shields.io/github/license/juhkff/juhkff-plugin"/>
 <img src ="https://img.shields.io/github/languages/top/juhkff/juhkff-plugin?logo=github"/>
 


### PR DESCRIPTION
## Summary by Sourcery

Add a Node.js badge and correct the GitHub spelling in the project README

Documentation:
- Add Node.js badge to README
- Fix typo from 'Gihub' to 'Github' in README badge